### PR TITLE
Fixing redundant `src-block' snippet insert at end of buffer.

### DIFF
--- a/el2org.el
+++ b/el2org.el
@@ -145,7 +145,15 @@
     (with-temp-buffer
       (insert-file-contents el-file)
       (emacs-lisp-mode)
-      (let ((case-fold-search t))
+      (let ((case-fold-search t)
+            (buffer-end-of-newlineP
+             (save-excursion (goto-char (point-max))
+                             (forward-line 0)
+                             (if (string-match
+                                  "^$"
+                                  (buffer-substring-no-properties (point) (point-max)))
+                                 t
+                               nil))))
         ;; Protect existing "begin_src emacs-lisp"
         (goto-char (point-min))
         (while (re-search-forward "#[+]begin_src[ ]+emacs-lisp" nil t)
@@ -160,9 +168,11 @@
           (while status
             (thing-at-point--end-of-sexp)
             (end-of-line)
-            (unless (< (point) (point-max))
-              (setq status nil))
-            (insert "\n;; #+end_src")))
+            (if (< (point) (point-max))
+                (insert "\n;; #+end_src")
+              (setq status nil)
+              (unless buffer-end-of-newlineP
+                (insert "\n;; #+end_src")))))
         ;; Add "#+begin_src"
         (goto-char (point-max))
         (let ((status t))

--- a/el2org.el
+++ b/el2org.el
@@ -146,7 +146,7 @@
       (insert-file-contents el-file)
       (emacs-lisp-mode)
       (let ((case-fold-search t)
-            (buffer-end-of-newlineP
+            (buffer-end-of-newline-p
              (save-excursion (goto-char (point-max))
                              (forward-line 0)
                              (if (string-match
@@ -171,7 +171,7 @@
             (if (< (point) (point-max))
                 (insert "\n;; #+end_src")
               (setq status nil)
-              (unless buffer-end-of-newlineP
+              (unless buffer-end-of-newline-p
                 (insert "\n;; #+end_src")))))
         ;; Add "#+begin_src"
         (goto-char (point-max))


### PR DESCRIPTION
Analyzing:

Emacs save buffer with newline defaultly refer to vairable
`require-final-newline' and `mode-require-final-newline', this makes
the last `thing-at-point--end-of-sexp' jumping to the newline at
buffer bottom without context lexical status checking while the simple
'src-block' inserting condition gained of '(< (point) (point-max))'
can not give more limitation for as.

This patching adding one buffer type checking for there the end of
newline way along for adding one  closure 'let' variable
`buffer-end-of-newlineP' for doing thus.